### PR TITLE
Split read support.

### DIFF
--- a/src/FindTranslocations.cpp
+++ b/src/FindTranslocations.cpp
@@ -208,7 +208,6 @@ int main(int argc, char *argv[]) {
 		fileQueue.pop();
 		outputFileHeader = fileQueue.front();
 
-	
 		// Now parse BAM header and extract information about genome lenght
 		
 		BamReader bamFile;
@@ -376,9 +375,9 @@ int main(int argc, char *argv[]) {
 
 		}
 		
-        int ploidity = 2;
-        if(vm.count("ploidiy")){
-            ploidity = vm["ploidiy"].as<int>();
+        int ploidy = 2;
+        if(vm.count("ploidy")){
+            ploidy = vm["ploidy"].as<int>();
         }
 		size_t start = time(NULL);
 		Cov *calculateCoverage;
@@ -388,7 +387,7 @@ int main(int argc, char *argv[]) {
 
 		StructuralVariations *FindTranslocations;
 		FindTranslocations = new StructuralVariations();
-		FindTranslocations -> findTranslocationsOnTheFly(alignmentFile, min_insert, max_insert, outtie, minimum_mapping_quality, minimumSupportingPairs, coverage, meanInsert, insertStd, outputFileHeader, indexFile,contigsNumber,ploidity);
+		FindTranslocations -> findTranslocationsOnTheFly(alignmentFile, min_insert, max_insert, outtie, minimum_mapping_quality, minimumSupportingPairs, coverage, meanInsert, insertStd, outputFileHeader, indexFile,contigsNumber,ploidy);
 
 
 	//if the find copy number variation module is chosen
@@ -484,8 +483,8 @@ int main(int argc, char *argv[]) {
 		}
 
         int ploidy = 2;
-        if(vm.count("ploidiy")){
-            ploidy = vm["ploidiy"].as<int>();
+        if(vm.count("ploidy")){
+            ploidy = vm["ploidy"].as<int>();
         }
 
 		Region *AnalyseRegion;

--- a/src/common.h
+++ b/src/common.h
@@ -22,14 +22,15 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 
+#ifndef M_PI
 #define M_PI 3.141592654
+#endif
 
 #ifdef INLINE_DISABLED
 #define INLINE
 #else
 #define INLINE inline
 #endif
-
 
 using namespace BamTools;
 using namespace std;
@@ -277,6 +278,8 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
 	// mates on different contigs
 	uint32_t matedDifferentContig 		= 0; // number of contig placed in a different contig
 	uint64_t matedDifferentContigLength = 0; // total number of reads placed in different contigs
+	// split reads
+	uint32_t splitReads = 0;
 
 	float C_A = 0; // total read coverage
 	float S_A = 0; // total span coverage
@@ -301,6 +304,12 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
 		if (read_status != unmapped and read_status != lowQualty) {
 			mappedReads ++;
 			mappedReadsLength += al.Length;
+			
+			al.BuildCharData();
+			
+			if (al.HasTag("SA")) {
+			  splitReads ++;
+			}
 		}
 
 		if (al.IsFirstMate() && read_status) {
@@ -347,7 +356,7 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
 		  case pair_wrongOrientation:
 			  wronglyOrientedReads ++;
 			  wronglyOrientedReadsLength += al.Length ;
-			  break;
+			  break;			  
 		  default:
 		     cout << "This should never be printed\n";
 		     break;
@@ -359,11 +368,12 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
 	cout << "\t total reads number "	<< reads << "\n";
 	cout << "\t total mapped reads " 	<< mappedReads << "\n";
 	cout << "\t total unmapped reads " 	<< unmappedReads << "\n";
-	cout << "\t proper pairs " 			<< matedReads << "\n";
+	cout << "\t proper pairs " 	       	<< matedReads << "\n";
+	cout << "\t split reads "               << splitReads << "\n";
 	cout << "\t wrong distance "		<< wrongDistanceReads << "\n";
 	cout << "\t zero quality reads " 	<< lowQualityReads << "\n";
 	cout << "\t wrongly contig "		<< matedDifferentContig << "\n";
-	cout << "\t singletons " 			<< singletonReads << "\n";
+	cout << "\t singletons " 		<< singletonReads << "\n";
 
 	uint32_t total = matedReads + wrongDistanceReads +  wronglyOrientedReads +  matedDifferentContig + singletonReads  ;
 	cout << "\ttotal " << total << "\n";

--- a/src/data_structures/AnalyseRegion.cpp
+++ b/src/data_structures/AnalyseRegion.cpp
@@ -176,7 +176,8 @@ void Region::region(string bamFile,string baiFile,string regionFile,string outpu
 			if(estimatedDistance < 0){
 				estimatedDistance=1;
 			}
-			window->VCFLine(chrB,startB,endB,startA,endA,pairsFormingLink,numLinksToChr2,estimatedDistance);
+			int splitsFormingLink = 0; // no split read support here yet..
+			window->VCFLine(chrB,startB,endB,startA,endA,pairsFormingLink,splitsFormingLink,numLinksToChr2,estimatedDistance);
 		}
 		window->interChrVariationsVCF.close();
 		window->intraChrVariationsVCF.close();

--- a/src/data_structures/ProgramModules.h
+++ b/src/data_structures/ProgramModules.h
@@ -28,7 +28,7 @@ public:
 	StructuralVariations();
 	//main function
 	void findTranslocationsOnTheFly(string bamFileName, int32_t min_insert,  int32_t max_insert, bool outtie, uint16_t minimum_mapping_quality,
-		uint32_t minimumSupportingPairs, float meanCoverage, float meanInsertSize, float StdInsertSize, string outputFileHeader, string indexFile, int contigsNumber,int ploidity);
+		uint32_t minimumSupportingPairs, float meanCoverage, float meanInsertSize, float StdInsertSize, string outputFileHeader, string indexFile, int contigsNumber,int ploidy);
 };
 
 //This class contains functions used to recognize and read vcf and bed files

--- a/src/data_structures/Translocation.h
+++ b/src/data_structures/Translocation.h
@@ -18,6 +18,8 @@ public:
 	int chr;
 
 	vector< queue<BamAlignment> >	eventReads;
+	
+	vector< vector<BamAlignment> > eventSplitReads;
 
 	vector<long> covOnChrA;
 	vector<long> tmpCovOnChrA;
@@ -34,7 +36,7 @@ public:
 	float std_insert;
 	int minimumPairs;
 	float meanCoverage;
-    int ploidity;
+	int ploidy;
 
 	//the file name of the bamfile
 	string bamFileName;
@@ -66,7 +68,7 @@ public:
 	vector<double> computeOrientation(queue<BamAlignment> alignmentQueue,long Astart,long Aend,long Bstart,long Bend);//compute the orientation of the read and the mate
 	vector<string> classification(int chr, int startA,int endA,double covA,int startB,int endB,double covB,int meanInsert,int STDInsert,bool outtie,vector<double> isReverse);
 	string VCFHeader();
-	void VCFLine(int chr2,int startSecondWindow, int stopSecondWindow,int startchrA,int stopchrA,int pairsFormingLink,int numLinksToChr2,int estimatedDistance);
+	void VCFLine(int chr2,int startSecondWindow, int stopSecondWindow,int startchrA,int stopchrA,int pairsFormingLink,int splitsFormingLink,int numLinksToChr2,int estimatedDistance);
 	vector<int> findLinksToChr2(queue<BamAlignment> ReadQueue,long startChrA,long stopChrA,long startChrB,long endChrB, int pairsFormingLink);
 	float computeCoverageB(int chrB, int start, int end, int32_t secondWindowLength); //computes the coverage of the window of chromosome B
 	bool computeVariations(int chr2);


### PR DESCRIPTION
Initial split reads support.
<img width="1420" alt="screen shot 2016-03-17 at 08 56 28" src="https://cloud.githubusercontent.com/assets/758570/13840150/e3220ccc-ec20-11e5-95f4-6f0962374ed6.png">

There are a few obvious things to add later:
- [ ] narrow windows to more exact coordinate based on split reads. 
- [ ] allow split reads to seed new windows - for now I just add compatible splits to current open window. 
- [ ] use split reads in evidence calculation for whether to accept event as true.
The first two should be straightforward, whereas the latter will require some brainstorming and potentially actual math on a board. :smile_cat: 

Oh, and corrected the spelling of ploidy. There might be an issue with the CLI activation of that - will get back with an issue on that. But, relates to old issue of treatment of sex chromosomes.